### PR TITLE
Refactor: Update eventFilter in MainWindow to set default box display…

### DIFF
--- a/src/mainwindow.py
+++ b/src/mainwindow.py
@@ -271,8 +271,9 @@ class MainWindow(QMainWindow):
         self.ui.comboBox_boxDisplayStyle.currentIndexChanged.connect(
             partial(self.globalSettingsChanged, "box_display_style")
         )
+        box_display_style = fetch_data("scoresight.json", "box_display_style", 3)
         self.ui.comboBox_boxDisplayStyle.setCurrentIndex(
-            fetch_data("scoresight.json", "box_display_style", 3)
+            box_display_style if type(box_display_style) == int else 3
         )
 
         self.ui.checkBox_updateOnchange.toggled.connect(self.toggleUpdateOnChange)


### PR DESCRIPTION
… style

This commit updates the eventFilter method in the MainWindow class to set the default box display style. The previous implementation used the fetch_data function to retrieve the box display style from the "scoresight.json" file, but it did not handle cases where the retrieved value was not an integer. This commit introduces a check to ensure that the retrieved value is an integer and sets it as the current index of the comboBox_boxDisplayStyle. If the retrieved value is not an integer, the default index of 3 is used instead.