### PR TITLE
Load external OCR model

### DIFF
--- a/src/tesseract.py
+++ b/src/tesseract.py
@@ -113,9 +113,9 @@ class TextDetector:
         else:
             self.setOcrModel(TextDetector.OcrModelIndex.DAKTRONICS)
 
-    def setOcrModel(self, ocrModelIndex: OcrModelIndex | str | None = None):
+    def setOcrModel(self, ocrModelIndex: OcrModelIndex | int | str | None = None):
         ocr_model = None
-        external_folder = None
+        model_folder = resource_path("tesseract", "tessdata")
         if ocrModelIndex == TextDetector.OcrModelIndex.DAKTRONICS:
             ocr_model = "daktronics"
         elif ocrModelIndex == TextDetector.OcrModelIndex.SCOREBOARD_GENERAL:
@@ -128,25 +128,22 @@ class TextDetector:
             # check the model file exists at the path
             if path.exists(ocrModelIndex):
                 # Take the folder as the tessdata folder
-                external_folder = path.dirname(ocrModelIndex)
+                model_folder = path.dirname(ocrModelIndex)
                 # Take the model name without extension as the "language"
                 ocr_model = path.basename(ocrModelIndex)
                 ocr_model = path.splitext(ocr_model)[0]
-        elif ocr_model is None:
+
+        if ocr_model is None:
             return
 
-        logger.info(f"Setting OCR model to {ocr_model}")
+        logger.info(f"Setting OCR model to {ocr_model} from {model_folder}")
 
         with self.api_lock:
             if self.api is not None:
                 self.api.End()
                 self.api = None
             self.api = PyTessBaseAPI(
-                path=(
-                    resource_path("tesseract", "tessdata")
-                    if external_folder is None
-                    else external_folder
-                ),
+                path=model_folder,
                 lang=ocr_model,
             )
             # single word PSM

--- a/src/tesseract.py
+++ b/src/tesseract.py
@@ -15,6 +15,7 @@ from text_detection_target import (
     TextDetectionTarget,
     TextDetectionTargetWithResult,
 )
+from sc_logging import logger
 
 
 def autocrop(image_in):
@@ -112,25 +113,40 @@ class TextDetector:
         else:
             self.setOcrModel(TextDetector.OcrModelIndex.DAKTRONICS)
 
-    def setOcrModel(self, ocrModelIndex):
+    def setOcrModel(self, ocrModelIndex: OcrModelIndex | str | None = None):
         ocr_model = None
-        if ocrModelIndex == self.OcrModelIndex.DAKTRONICS:
+        external_folder = None
+        if ocrModelIndex == TextDetector.OcrModelIndex.DAKTRONICS:
             ocr_model = "daktronics"
-        if ocrModelIndex == self.OcrModelIndex.SCOREBOARD_GENERAL:
+        elif ocrModelIndex == TextDetector.OcrModelIndex.SCOREBOARD_GENERAL:
             ocr_model = "scoreboard_general"
-        if ocrModelIndex == self.OcrModelIndex.GENERAL_ENGLISH:
+        elif ocrModelIndex == TextDetector.OcrModelIndex.GENERAL_ENGLISH:
             ocr_model = "eng"
-        if ocrModelIndex == self.OcrModelIndex.SCOREBOARD_GENERAL_LARGE:
+        elif ocrModelIndex == TextDetector.OcrModelIndex.SCOREBOARD_GENERAL_LARGE:
             ocr_model = "scoreboard_general_large"
-        if ocr_model is None:
+        elif isinstance(ocrModelIndex, str):
+            # check the model file exists at the path
+            if path.exists(ocrModelIndex):
+                # Take the folder as the tessdata folder
+                external_folder = path.dirname(ocrModelIndex)
+                # Take the model name without extension as the "language"
+                ocr_model = path.basename(ocrModelIndex)
+                ocr_model = path.splitext(ocr_model)[0]
+        elif ocr_model is None:
             return
+
+        logger.info(f"Setting OCR model to {ocr_model}")
 
         with self.api_lock:
             if self.api is not None:
                 self.api.End()
                 self.api = None
             self.api = PyTessBaseAPI(
-                path=resource_path("tesseract", "tessdata"),
+                path=(
+                    resource_path("tesseract", "tessdata")
+                    if external_folder is None
+                    else external_folder
+                ),
                 lang=ocr_model,
             )
             # single word PSM


### PR DESCRIPTION
… external OCR model

- Updated the `MainWindow` class in `mainwindow.py` to set the default box display style for the OCR model combo box.
- Added the ability to load a custom OCR model file in the `ocrModelChanged` method of `MainWindow`.
- Updated the `setOcrModel` method in `TextDetector` class of `tesseract.py` to handle loading external OCR models.