### PR TITLE
Refactor: Update ResizableRect and ResizableRectWithNameTypeAndResult…

### DIFF
--- a/src/source_view.py
+++ b/src/source_view.py
@@ -123,11 +123,7 @@ class ImageViewer(CameraView):
             boxFound = self.findBox(detectionTarget.name)
             if boxFound is None:
                 boxFound = ResizableRectWithNameTypeAndResult(
-                    detectionTarget.x(),
-                    detectionTarget.y(),
-                    detectionTarget.width(),
-                    detectionTarget.height(),
-                    detectionTarget.name,
+                    detectionTarget,
                     # image size
                     self.scene.sceneRect().width(),
                     onCenter=False,

--- a/src/source_view.py
+++ b/src/source_view.py
@@ -1,5 +1,5 @@
 import math
-from PySide6.QtCore import QPointF, Qt, QTimer
+from PySide6.QtCore import QPointF, Qt, QTimer, QRectF
 from PySide6.QtGui import QBrush, QColor, QMouseEvent, QPen, QPolygonF
 from PySide6.QtWidgets import (
     QGraphicsPolygonItem,
@@ -151,7 +151,7 @@ class ImageViewer(CameraView):
                 if item.name not in done_targets:
                     self.scene.removeItem(item)
 
-    def boxChanged(self, name, rect):
+    def boxChanged(self, name: str, rect: QRectF, mini_rects: list[QRectF]):
         # update the detection target in the storage
         detectionTargets: list[TextDetectionTarget] = (
             self.detectionTargetsStorage.get_data()
@@ -165,6 +165,7 @@ class ImageViewer(CameraView):
                 self.detectionTargetsStorage.edit_item(
                     detectionTarget.name, detectionTarget
                 )
+                detectionTarget.mini_rects = mini_rects
                 break
 
     def findBox(self, name):

--- a/src/text_detection_target.py
+++ b/src/text_detection_target.py
@@ -39,13 +39,23 @@ class OCRResultPerCharacterSmoother:
 
 
 class TextDetectionTarget(QRectF):
-    def __init__(self, x, y, width, height, name: str, settings: dict = {}):
+    def __init__(
+        self,
+        x,
+        y,
+        width,
+        height,
+        name: str,
+        settings: dict = {},
+        mini_rects: list[QRectF] = [],
+    ):
         super().__init__(x, y, width, height)
         self.name = name
         self.settings = settings
         self.ocrResultPerCharacterSmoother = OCRResultPerCharacterSmoother()
         self.last_image = None
         self.last_text = None
+        self.mini_rects: list[QRectF] = mini_rects
 
 
 class TextDetectionTargetWithResult(TextDetectionTarget):


### PR DESCRIPTION
… classes

This commit refactors the ResizableRect and ResizableRectWithNameTypeAndResult classes in the src/resizable_rect.py file.

- Import statements have been updated to include the TextDetectionTarget and TextDetectionTargetWithResult classes from the text_detection_target module.
- The setFlags method in the MiniRect class has been updated to use the QGraphicsItem.GraphicsItemFlag enum for improved readability.
- The ResizableRectWithNameTypeAndResult class now accepts a TextDetectionTarget object as a parameter instead of individual x, y, width, height, and name parameters.
- The setupAddButton method in the ResizableRectWithNameTypeAndResult class has been modified to use a smaller add button size and display a "+" symbol instead of "Add".
- The mini_rects attribute in the ResizableRectWithNameTypeAndResult class is now initialized with MiniRect objects created from the mini_rects attribute of the TextDetectionTarget object.

These changes improve the readability and maintainability of the code.